### PR TITLE
feat :: 현재 버스 인원수 표시 #41

### DIFF
--- a/src/components/MyInfo/Contents/BusApply/BusOption/BusOption.tsx
+++ b/src/components/MyInfo/Contents/BusApply/BusOption/BusOption.tsx
@@ -1,5 +1,5 @@
-import { Bus } from "../../../../../types/busApply/busApply.type";
-import * as S from "./style";
+import { Bus } from '../../../../../types/busApply/busApply.type';
+import * as S from './style';
 
 interface Props {
   data: Bus;
@@ -8,32 +8,26 @@ interface Props {
 }
 
 const BusOption = ({ data, isSelect, onChangeApplyBus }: Props) => {
-  const [busNumber, busName] = data.busName.split(" ");
+  const [busNumber, busName] = data.busName.split(' ');
 
   return (
-    <S.BusOptionWrap
-      isSelect={isSelect}
-      onClick={() => onChangeApplyBus(data.id)}
-    >
-      {busNumber === "미탑승" ? (
+    <S.BusOptionWrap isSelect={isSelect} onClick={() => onChangeApplyBus(data.id)}>
+      {busNumber === '미탑승' ? (
         <>
+          <S.BusOptionStationText isSelect={isSelect}>{busNumber}</S.BusOptionStationText>
           <S.BusOptionStationText isSelect={isSelect}>
-            {busNumber}
-          </S.BusOptionStationText>
-          <S.BusOptionStationText isSelect={isSelect}>
-            ({data.leaveTime.split(" ")[1].substring(0, 5)})
+            ({data.leaveTime.split(' ')[1].substring(0, 5)})
           </S.BusOptionStationText>
         </>
       ) : (
         <>
+          <S.BusOptionStationText isSelect={isSelect}>{busNumber}</S.BusOptionStationText>
           <S.BusOptionStationText isSelect={isSelect}>
-            {busNumber}
+            {data.applyCount}/{data.peopleLimit}
           </S.BusOptionStationText>
+          <S.BusOptionStationText isSelect={isSelect}>{busName}</S.BusOptionStationText>
           <S.BusOptionStationText isSelect={isSelect}>
-            {busName}
-          </S.BusOptionStationText>
-          <S.BusOptionStationText isSelect={isSelect}>
-            ({data.leaveTime.split(" ")[1].substring(0, 5)})
+            ({data.leaveTime.split(' ')[1].substring(0, 5)})
           </S.BusOptionStationText>
         </>
       )}

--- a/src/hooks/busApply/useBusApply.ts
+++ b/src/hooks/busApply/useBusApply.ts
@@ -1,13 +1,13 @@
-import { B1ndToast } from "@b1nd/b1nd-toastify";
-import { useEffect, useState } from "react";
-import busApplyRepository from "../../repository/busApply/busApply.repository";
-import { Bus } from "../../types/busApply/busApply.type";
+import { B1ndToast } from '@b1nd/b1nd-toastify';
+import { useEffect, useState } from 'react';
+import busApplyRepository from '../../repository/busApply/busApply.repository';
+import { Bus } from '../../types/busApply/busApply.type';
 
 const useBusApply = () => {
   const [serverBusData, setServerBusData] = useState<Bus[]>([]);
   const [selectedBusId, setSelectedBusId] = useState<number>(-1);
   const [selectBusId, setSelectBusId] = useState<number>(-1);
-  const [busDate, setBusDate] = useState("");
+  const [busDate, setBusDate] = useState('');
   const [isChange, setIsChange] = useState(false);
 
   const mappingBusData = async () => {
@@ -46,10 +46,11 @@ const useBusApply = () => {
   const onSubmitBusApply = async () => {
     try {
       await busApplyRepository.postBusApply({ idx: String(selectBusId) });
-      B1ndToast.showSuccess("버스 신청 성공");
+      B1ndToast.showSuccess('버스 신청 성공');
+      mappingBusData();
       setSelectedBusId(selectBusId);
     } catch (error) {
-      B1ndToast.showError("버스 신청 실패");
+      B1ndToast.showError('버스 신청 실패');
     }
   };
 
@@ -58,10 +59,11 @@ const useBusApply = () => {
       await busApplyRepository.patchBusApply({
         idx: String(selectBusId),
       });
-      B1ndToast.showSuccess("버스 수정 성공");
+      B1ndToast.showSuccess('버스 수정 성공');
+      mappingBusData();
       setSelectedBusId(selectBusId);
     } catch (error) {
-      B1ndToast.showInfo("버스 수정 실패");
+      B1ndToast.showInfo('버스 수정 실패');
     }
   };
   const deleteBusApply = async () => {
@@ -69,11 +71,12 @@ const useBusApply = () => {
       await busApplyRepository.deleteBusApply({
         idx: String(selectBusId),
       });
-      B1ndToast.showSuccess("버스 신청 취소");
+      B1ndToast.showSuccess('버스 신청 취소');
+      mappingBusData();
       setSelectBusId(-1);
       setSelectedBusId(-1);
     } catch (error) {
-      B1ndToast.showInfo("버스 신청취소 실패");
+      B1ndToast.showInfo('버스 신청취소 실패');
     }
   };
   const onChangeApplyBus = (busId: number) => setSelectBusId(busId);


### PR DESCRIPTION
- 현재 내정보 페이지에서 버스 변경 가능
- 변경 시 버스의 총인원과 현재 탑승 인원이 표시되지 않아 불편하다는 피드백 수용
- 기존 버스 변경, 취소 시 캐싱이 되지않던 문제도 함께 해결

### before
<img width="869" alt="스크린샷 2024-11-21 오후 2 53 43" src="https://github.com/user-attachments/assets/38ca4b2f-5621-4d7c-854b-c91e9fe8e3b1">

### after
<img width="865" alt="스크린샷 2024-11-21 오후 2 53 57" src="https://github.com/user-attachments/assets/ac8f0ce4-b27c-4098-9972-cfdba55d6359">
