### PR TITLE
Feature/#51 mypage profile ux

### DIFF
--- a/src/components/Myprofile/ChangeProfile/index.tsx
+++ b/src/components/Myprofile/ChangeProfile/index.tsx
@@ -1,18 +1,11 @@
-import {
-  Avatar,
-  DodamDialog,
-  DodamFilledButton,
-  DodamTextField,
-  Plus,
-} from "@b1nd/dds-web";
-import { useState, ChangeEvent } from "react";
+import { Avatar, DodamFilledButton, DodamTextField, Plus } from "@b1nd/dds-web";
 import { ModalContent } from "../ChangePwModal/style";
 import { ChangeProfileImg, ChangeProfileTitle, FlexBox } from "./style";
-import { usePatchStudentInfo, usePatchMainProfile } from "queries/Profile/profile.query";
-import Modal from "components/Common/Modal";
+import useChangeProfile from "hooks/Profile/useChangeProfile";
+import { DEFAULT_PREVIEW } from "hooks/Profile/useProfileImage";
 import { B1ndToast } from "@b1nd/b1nd-toastify";
+import Modal from "components/Common/Modal";
 import { Profile } from "types/Profile/profile.type";
-import FileUpload from "repositories/Profile/fileUpload";
 
 interface ModalProps {
   isOpen: boolean;
@@ -21,100 +14,43 @@ interface ModalProps {
 }
 
 const ChangeProfile = ({ isOpen, handleSet, user }: ModalProps) => {
-  if (!user) return null;
+  const {
+    formData,
+    previewImage,
+    onChange,
+    onChangeImage,
+    onSubmit,
+    isBusy,
+    onResetToDefault,
+  } = useChangeProfile(user);
 
-  //사실 이렇게 하면 안되지만 빨리 개발하기 위해서 어쩔수 없는 선택이었습니다... 쏘리
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const patchStudent = usePatchStudentInfo();
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const patchProfile = usePatchMainProfile();
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const [formData, setFormData] = useState({
-    name: user.name ?? "",
-    phone: user.phone ?? "",
-    email: user.email ?? "",
-    grade: user.student?.grade?.toString() ?? "",
-    room: user.student?.room?.toString() ?? "",
-    number: user.student?.number?.toString() ?? "",
-  });
-// eslint-disable-next-line react-hooks/rules-of-hooks
-  const [previewImage, setPreviewImage] = useState(user.profileImage ?? null);
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const [uploadImage, setUploadImage] = useState<File | null>(null);
-
-  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const { name, value } = e.target;
-    setFormData((prev) => ({ ...prev, [name]: value }));
-  };
-
-  const onChangeImage = (e: ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (file) {
-      setUploadImage(file);
-      setPreviewImage(URL.createObjectURL(file));
-    }
-    DodamDialog.alert("이미지 수정하고 완료 버튼을 눌러주세요")
-  };
-
-  const onModifyStudentInfo = async () => {
-    const grade = parseInt(formData.grade);
-    const room = parseInt(formData.room);
-    const number = parseInt(formData.number);
-
-    if (
-      grade === user.student?.grade &&
-      room === user.student?.room &&
-      number === user.student?.number
-    ) {
-      B1ndToast.showInfo("학번 정보를 변경해주세요.");
+  const handleComplete = async () => {
+    const res = await onSubmit();
+    if (!res) return;
+    if (res.success || res.reason === "noChanges") {
+      B1ndToast.showSuccess("프로필 정보가 수정되었습니다.");
+      handleSet();
       return;
     }
-
-    patchStudent.mutate(
-      { grade, room, number },
-      {
-        onSuccess: () => {
-          B1ndToast.showSuccess("학번 정보가 성공적으로 수정되었습니다.");
-        },
-        onError: () => {
-          B1ndToast.showError("학번 수정에 실패했습니다.");
-        },
-      }
-    );
+    B1ndToast.showError("프로필 정보 수정에 실패했습니다.");
   };
-
-  const onSubmitProfileInfo = async () => {
-    let profileImageUrl: string | null = user.profileImage ?? null;
-
-    if (uploadImage) {
-      const formDataToUpload = new FormData();
-      formDataToUpload.append("file", uploadImage);
-
-      const { data } = await FileUpload.postFileUpload(formDataToUpload);
-      profileImageUrl = data;
-
-      setPreviewImage(null);
-    }
-
-    patchProfile.mutate({
-      email: formData.email,
-      phone: formData.phone,
-      profileImage: profileImageUrl,
-    });
-
-    handleSet();
-  };
-
-
+  // eslint-disable-next-line
+  if (!user) return null;
 
   return (
     <Modal isOpen={isOpen} close={handleSet}>
-      <ModalContent onClick={(e: React.MouseEvent<HTMLDivElement>) => e.stopPropagation()}>
+      <ModalContent
+        onClick={(e: React.MouseEvent<HTMLDivElement>) => e.stopPropagation()}
+      >
         <ChangeProfileTitle>프로필 수정</ChangeProfileTitle>
 
         <ChangeProfileImg>
-          {user.profileImage ? (
-            <img src={previewImage ? previewImage : user.profileImage} alt="" />
+          {previewImage === DEFAULT_PREVIEW ? (
+            <Avatar size="xxl" color="staticWhite" />
+          ) : previewImage ? (
+            <img src={previewImage} alt="" />
+          ) : user.profileImage ? (
+            <img src={user.profileImage} alt="" />
           ) : (
             <Avatar size="xxl" color="staticWhite" />
           )}
@@ -127,21 +63,78 @@ const ChangeProfile = ({ isOpen, handleSet, user }: ModalProps) => {
             style={{ display: "none" }}
             onChange={onChangeImage}
           />
-          <span>기본 프로필로 변경</span>
+          <span style={{ cursor: "pointer" }} onClick={onResetToDefault}>
+            기본 프로필로 변경
+          </span>
         </ChangeProfileImg>
 
-        <DodamTextField id="name" name="name" type="text" value={formData.name} label="이름" onChange={onChange} />
-        <DodamTextField id="phone" name="phone" type="text" value={formData.phone} label="전화번호" onChange={onChange} />
-        <DodamTextField id="email" name="email" type="text" value={formData.email} label="이메일" onChange={onChange} />
+        <DodamTextField
+          id="name"
+          name="name"
+          type="text"
+          value={formData.name}
+          label="이름"
+          onChange={onChange}
+        />
+        <DodamTextField
+          id="phone"
+          name="phone"
+          type="text"
+          value={formData.phone}
+          label="전화번호"
+          onChange={onChange}
+        />
+        <DodamTextField
+          id="email"
+          name="email"
+          type="text"
+          value={formData.email}
+          label="이메일"
+          onChange={onChange}
+        />
 
         <FlexBox>
-          <DodamTextField id="grade" name="grade" type="text" value={formData.grade} label="학년" onChange={onChange} />
-          <DodamTextField id="room" name="room" type="text" value={formData.room} label="반" onChange={onChange} />
-          <DodamTextField id="number" name="number" type="text" value={formData.number} label="번호" onChange={onChange} />
-          <DodamFilledButton width={30} size="Small" text="학번수정" textTheme="staticWhite" onClick={onModifyStudentInfo} />
+          <DodamTextField
+            id="grade"
+            name="grade"
+            type="text"
+            value={formData.grade}
+            label="학년"
+            onChange={onChange}
+          />
+          <DodamTextField
+            id="room"
+            name="room"
+            type="text"
+            value={formData.room}
+            label="반"
+            onChange={onChange}
+          />
+          <DodamTextField
+            id="number"
+            name="number"
+            type="text"
+            value={formData.number}
+            label="번호"
+            onChange={onChange}
+          />
         </FlexBox>
 
-        <DodamFilledButton size="Large" text="완료" textTheme="staticWhite" onClick={onSubmitProfileInfo}/>
+        {isBusy ? (
+          <DodamFilledButton
+            size="Large"
+            text="처리중..."
+            textTheme="staticWhite"
+            onClick={() => {}}
+          />
+        ) : (
+          <DodamFilledButton
+            size="Large"
+            text="완료"
+            textTheme="staticWhite"
+            onClick={handleComplete}
+          />
+        )}
       </ModalContent>
     </Modal>
   );

--- a/src/components/Myprofile/ChangeProfile/style.ts
+++ b/src/components/Myprofile/ChangeProfile/style.ts
@@ -1,9 +1,6 @@
 import { DodamShape, DodamTypography } from "@b1nd/dds-web";
 import styled from "styled-components";
 
-export const ChangeProfileModal = styled.div`
-    
-`
 
 export const ChangeProfileTitle = styled.span`
     color: ${({theme})=>theme.labelNormal};

--- a/src/hooks/Profile/useChangeProfile.ts
+++ b/src/hooks/Profile/useChangeProfile.ts
@@ -1,0 +1,87 @@
+import { ChangeEvent, useState } from "react";
+import { Profile } from "types/Profile/profile.type";
+import useProfileForm from "hooks/Profile/useProfileForm";
+import useProfileImage from "hooks/Profile/useProfileImage";
+import useProfileSubmit from "hooks/Profile/useProfileSubmit";
+
+interface FormDataState {
+  name: string;
+  phone: string;
+  email: string;
+  grade: string;
+  room: string;
+  number: string;
+}
+
+interface SubmitResult {
+  success: boolean;
+  studentError?: boolean;
+  profileError?: boolean;
+  reason?: "busy" | "noChanges" | "upload" | string;
+}
+
+interface UseChangeProfileReturn {
+  formData: FormDataState;
+  previewImage: string | null;
+  onChange: (e: ChangeEvent<HTMLInputElement>) => void;
+  onChangeImage: (e: ChangeEvent<HTMLInputElement>) => void;
+  onSubmit: () => Promise<SubmitResult>;
+  isBusy: boolean;
+  onResetToDefault: () => void;
+}
+
+const useChangeProfile = (user?: Profile | null): UseChangeProfileReturn => {
+  const { formData, onChange, getParsedNumbers } = useProfileForm(user);
+  const {
+    preview,
+    isUploading,
+    onChangeImage,
+    onResetToDefault,
+    uploadIfNeeded,
+  } = useProfileImage(user?.profileImage ?? null);
+  const { submit } = useProfileSubmit();
+
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const onSubmit = async () => {
+    if (isSubmitting || isUploading) return { success: false, reason: "busy" };
+    try {
+      setIsSubmitting(true);
+
+      const uploadResult = await uploadIfNeeded();
+      if (uploadResult.error) {
+        return {
+          success: false,
+          studentError: false,
+          profileError: true,
+          reason: "upload",
+        };
+      }
+
+      const profileImageUrl = uploadResult.url;
+      const parsed = getParsedNumbers();
+
+      const result = await submit(
+        formData as any,
+        parsed,
+        profileImageUrl,
+        user,
+      );
+      return result;
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return {
+    formData,
+    previewImage: preview,
+    onChange,
+    onChangeImage,
+    onSubmit,
+    isBusy: isSubmitting || isUploading,
+    onResetToDefault,
+  };
+};
+
+export default useChangeProfile;

--- a/src/hooks/Profile/useProfileForm.ts
+++ b/src/hooks/Profile/useProfileForm.ts
@@ -1,0 +1,52 @@
+import { ChangeEvent, useEffect, useState } from "react";
+import { Profile } from "types/Profile/profile.type";
+
+export interface FormDataState {
+  name: string;
+  phone: string;
+  email: string;
+  grade: string;
+  room: string;
+  number: string;
+}
+
+const useProfileForm = (user?: Profile | null) => {
+  const [formData, setFormData] = useState<FormDataState>({
+    name: user?.name ?? "",
+    phone: user?.phone ?? "",
+    email: user?.email ?? "",
+    grade: user?.student?.grade?.toString() ?? "",
+    room: user?.student?.room?.toString() ?? "",
+    number: user?.student?.number?.toString() ?? "",
+  });
+
+  useEffect(() => {
+    if (!user) return;
+    setFormData({
+      name: user.name ?? "",
+      phone: user.phone ?? "",
+      email: user.email ?? "",
+      grade: user.student?.grade?.toString() ?? "",
+      room: user.student?.room?.toString() ?? "",
+      number: user.student?.number?.toString() ?? "",
+    });
+  }, [user]);
+
+  const onChange = (e: ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData((prev) => ({ ...prev, [name]: value }) as FormDataState);
+  };
+
+  const setForm = (next: FormDataState) => setFormData(next);
+
+  const getParsedNumbers = () => {
+    const gradeNum = formData.grade === "" ? null : parseInt(formData.grade);
+    const roomNum = formData.room === "" ? null : parseInt(formData.room);
+    const numberNum = formData.number === "" ? null : parseInt(formData.number);
+    return { gradeNum, roomNum, numberNum };
+  };
+
+  return { formData, onChange, setForm, getParsedNumbers };
+};
+
+export default useProfileForm;

--- a/src/hooks/Profile/useProfileImage.ts
+++ b/src/hooks/Profile/useProfileImage.ts
@@ -1,0 +1,117 @@
+import { ChangeEvent, useEffect, useState } from "react";
+import FileUpload from "repositories/Profile/fileUpload";
+
+export const DEFAULT_PREVIEW = "__DEFAULT_PREVIEW__";
+
+const useProfileImage = (initialUrl?: string | null) => {
+  const [preview, setPreview] = useState<string | null>(null);
+  const [objectUrl, setObjectUrl] = useState<string | null>(null);
+  const [isUploading, setIsUploading] = useState(false);
+
+  useEffect(() => {
+    return () => {
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [objectUrl]);
+
+  const setPreviewFromFile = (file: File | null) => {
+    if (objectUrl) {
+      URL.revokeObjectURL(objectUrl);
+      setObjectUrl(null);
+    }
+    if (!file) {
+      setPreview(null);
+      return;
+    }
+    const url = URL.createObjectURL(file);
+    setObjectUrl(url);
+    setPreview(url);
+  };
+
+  const setPreviewFromUrl = (url: string | null) => {
+    if (objectUrl) {
+      URL.revokeObjectURL(objectUrl);
+      setObjectUrl(null);
+    }
+    setPreview(url);
+  };
+
+  const resetToDefault = () => {
+    if (objectUrl) {
+      URL.revokeObjectURL(objectUrl);
+      setObjectUrl(null);
+    }
+    setPreview(DEFAULT_PREVIEW);
+  };
+
+  const upload = async (file: File): Promise<string> => {
+    setIsUploading(true);
+    try {
+      const form = new FormData();
+      form.append("file", file);
+      const res = await FileUpload.postFileUpload(form);
+      const uploadedUrl = (res as any)?.data ?? "";
+      return uploadedUrl;
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const [imageState, setImageState] = useState<{
+    file: File | null;
+    shouldReset: boolean;
+  }>({
+    file: null,
+    shouldReset: false,
+  });
+
+  useEffect(() => {
+    setPreviewFromUrl(initialUrl ?? null);
+    setImageState({ file: null, shouldReset: false });
+  }, [initialUrl]);
+
+  const onChangeImage = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0] ?? null;
+    if (file) {
+      setImageState({ file, shouldReset: false });
+      setPreviewFromFile(file);
+    }
+  };
+
+  const onResetToDefault = () => {
+    setImageState({ file: null, shouldReset: true });
+    resetToDefault();
+  };
+
+  const uploadIfNeeded = async (): Promise<{
+    url: string | null;
+    error?: boolean;
+  }> => {
+    const current = initialUrl ?? null;
+    if (imageState.file) {
+      try {
+        const url = await upload(imageState.file);
+        setPreviewFromUrl(url);
+        return { url };
+      } catch (e) {
+        return { url: null, error: true };
+      }
+    }
+    if (imageState.shouldReset) return { url: null };
+    return { url: current };
+  };
+
+  return {
+    preview,
+    setPreviewFromFile,
+    setPreviewFromUrl,
+    resetToDefault,
+    isUploading,
+    onChangeImage,
+    onResetToDefault,
+    uploadIfNeeded,
+    DEFAULT_PREVIEW,
+  };
+};
+
+export default useProfileImage;

--- a/src/hooks/Profile/useProfileSubmit.ts
+++ b/src/hooks/Profile/useProfileSubmit.ts
@@ -1,0 +1,98 @@
+import {
+  usePatchStudentInfo,
+  usePatchMainProfile,
+} from "queries/Profile/profile.query";
+import { Profile } from "types/Profile/profile.type";
+import patternCheck from "utils/patternCheck";
+
+interface FormDataState {
+  name: string;
+  phone: string;
+  email: string;
+  grade: string;
+  room: string;
+  number: string;
+}
+
+interface SubmitResult {
+  success: boolean;
+  studentError?: boolean;
+  profileError?: boolean;
+  reason?: "busy" | "noChanges" | "upload" | string;
+};
+
+const useProfileSubmit = () => {
+  const studentMutation = usePatchStudentInfo();
+  const profileMutation = usePatchMainProfile();
+
+  const submit = async (
+    formData: FormDataState,
+    parsed: {
+      gradeNum: number | null;
+      roomNum: number | null;
+      numberNum: number | null;
+    },
+    profileImageUrl: string | null,
+    user?: Profile | null,
+  ): Promise<SubmitResult> => {
+    const { gradeNum, roomNum, numberNum } = parsed;
+
+    const isStudentChanged =
+      (gradeNum !== null && gradeNum !== user?.student?.grade) ||
+      (roomNum !== null && roomNum !== user?.student?.room) ||
+      (numberNum !== null && numberNum !== user?.student?.number);
+
+    const isProfileChanged =
+      formData.name !== (user?.name ?? "") ||
+      formData.email !== (user?.email ?? "") ||
+      formData.phone !== (user?.phone ?? "") ||
+      profileImageUrl !== (user?.profileImage ?? null);
+
+    if (!isStudentChanged && !isProfileChanged)
+      return { success: false, reason: "noChanges" };
+
+    let studentError = false;
+    let profileError = false;
+
+    if (isProfileChanged) {
+      if (formData.email && !patternCheck.emailCheck(formData.email)) {
+        return { success: false, profileError: true, reason: "invalidEmail" };
+      }
+      if (formData.phone && !patternCheck.phoneCheck(formData.phone)) {
+        return { success: false, profileError: true, reason: "invalidPhone" };
+      }
+    }
+
+    if (isStudentChanged) {
+      try {
+        await studentMutation.mutateAsync({
+          grade: gradeNum ?? user?.student?.grade ?? 0,
+          room: roomNum ?? user?.student?.room ?? 0,
+          number: numberNum ?? user?.student?.number ?? 0,
+        });
+      } catch (err) {
+        studentError = true;
+      }
+    }
+
+    if (isProfileChanged) {
+      try {
+        await profileMutation.mutateAsync({
+          name: formData.name,
+          email: formData.email,
+          phone: formData.phone,
+          profileImage: profileImageUrl,
+        });
+      } catch (err) {
+        profileError = true;
+      }
+    }
+
+    const success = !studentError && !profileError;
+    return { success, studentError, profileError };
+  };
+
+  return { submit };
+};
+
+export default useProfileSubmit;

--- a/src/queries/Profile/profile.query.ts
+++ b/src/queries/Profile/profile.query.ts
@@ -2,48 +2,60 @@ import { B1ndToast } from "@b1nd/b1nd-toastify";
 import { AxiosError } from "axios";
 import token from "libs/Token/token";
 import { QUERY_KEYS } from "queries/queryKey";
-import { useMutation, useQuery, UseQueryOptions, UseQueryResult } from "react-query";
+import {
+  useMutation,
+  useQuery,
+  UseQueryOptions,
+  UseQueryResult,
+  useQueryClient,
+} from "react-query";
 import { patchStudentInfoParam } from "repositories/Profile/profile.param";
 import profileRepository from "repositories/Profile/profile.repository";
 import { myProfileResponse } from "types/Profile/profile.type";
 
-
 export const useGetProfileQuery = (
-    options?: UseQueryOptions<
-        myProfileResponse,
-        AxiosError,
-        myProfileResponse,
-        string
-    >
-  ): UseQueryResult<myProfileResponse, AxiosError> =>
-    useQuery(QUERY_KEYS.member.getMy, () => profileRepository.getMyProfileInfo(), {
+  options?: UseQueryOptions<
+    myProfileResponse,
+    AxiosError,
+    myProfileResponse,
+    string
+  >,
+): UseQueryResult<myProfileResponse, AxiosError> =>
+  useQuery(
+    QUERY_KEYS.member.getMy,
+    () => profileRepository.getMyProfileInfo(),
+    {
       ...options,
       onError: () => {
         B1ndToast.showError("토큰이 위조 됐습니다");
         token.clearToken();
         window.location.href = "/sign";
       },
-    });
+    },
+  );
 
-
-
-export const usePatchStudentInfo = ()=>{
-    const mutation = useMutation(({grade,
-      room,
-      number}:patchStudentInfoParam)=>
-        profileRepository.patchStudentInfo({grade,room,number}),
-      )
-      return mutation;
-}
-
+export const usePatchStudentInfo = () => {
+  const queryClient = useQueryClient();
+  return useMutation(
+    ({ grade, room, number }: patchStudentInfoParam) =>
+      profileRepository.patchStudentInfo({ grade, room, number }),
+    {
+      onSuccess: () => {
+        queryClient.invalidateQueries(QUERY_KEYS.member.getMy, {
+          refetchInactive: true,
+        });
+      },
+    },
+  );
+};
 
 export const usePatchMainProfile = () => {
+  const queryClient = useQueryClient();
   return useMutation(profileRepository.patchMainProfile, {
     onSuccess: () => {
-      B1ndToast.showSuccess("프로필 정보가 수정되었습니다.");
-    },
-    onError: () => {
-      B1ndToast.showError("프로필 정보 수정에 실패했습니다.");
+      queryClient.invalidateQueries(QUERY_KEYS.member.getMy, {
+        refetchInactive: true,
+      });
     },
   });
 };

--- a/src/types/Profile/profile.type.ts
+++ b/src/types/Profile/profile.type.ts
@@ -58,9 +58,9 @@ export interface myProfileResponse extends Response {
   status: number;
 }
 
-
 export interface mainProfile {
   email: string;
   profileImage: string | null;
+  name?: string;
   phone: string;
 }


### PR DESCRIPTION
##### **📘 한 내용**

## ⛳️ 작업 내용

- 프로필 수정 UX 리팩터 및 기능 개선 (이슈: #51)
- 프로필 폼 상태를 분리하여 useProfileForm 훅으로 이동
- 제출/검증/서버 호출 책임을 useProfileSubmit 훅으로 분리 
- 이미지 미리보기(preview) + 업로드 로직을 하나로 합쳐 useProfileImage 훅으로 통합 
- 컴포넌트에서 학번/프로필 수정 동작을 단일 완료 버튼으로 처리하고, 성공/실패 토스트를 컴포넌트에서 한 번만 표시하도록 변경 
- react-query mutation 성공 시 프로필 관련 쿼리 캐시 무효화 처리 일원화

<!-- 작업한 사항을 간략하게 적어주세요 -->

## 📸 스크린샷
<img width="2940" height="1848" alt="image" src="https://github.com/user-attachments/assets/fa25300e-1270-4219-a664-646a58803f14" />

<!-- 스크린샷으로 작업한 사항을 보여주세요 -->